### PR TITLE
chore: CODEOWNERS for auto-review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @armcrypto


### PR DESCRIPTION
Добавляет .github/CODEOWNERS для автозапроса ревью у @armcrypto.